### PR TITLE
Implemented CLI flag for listening address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+*.exe
+bin/

--- a/cmd/jGolleryServer/main.go
+++ b/cmd/jGolleryServer/main.go
@@ -1,8 +1,14 @@
 package main
 
-import . "jGollery/controller"
+import (
+	"flag"
+	. "jGollery/controller"
+)
 
 func main() {
+	addr := flag.String("addr", ":8080", `The address the application servers listens to`)
+	flag.Parse()
+
 	webController := NewWebController("static", "gallery")
-	webController.Run(":8080")
+	webController.Run(*addr)
 }


### PR DESCRIPTION
This PR contains the feature to specify the desired listening address as a command line flag when starting the server.

After compiling to `jgollery.exe`, it can be executed like so:

```
> jgollery.exe --addr=:8080
```
Also, an appropriate `.gitignore` has been added.